### PR TITLE
Keycloak fix + multi config support + config path change

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,20 +1,19 @@
-Kubernetes OIDC authentication client
-=====================================
+# Kubernetes OIDC authentication client
 
 This script is intended to be used as a helper script when using OIDC authentication together with Kubernetes.
 
-The script authenticates with an OIDC compliant identity provider using the Resource Owner Password Credentials grant flow with 
+The script authenticates with an OIDC compliant identity provider using the Resource Owner Password Credentials grant flow with
 a confidential client. It then sets the id and refresh tokens in the Kubernetes config file for the selected user,
- ready to be used by the Kubernetes kubectl command. The Kubernetes OIDC authenticator will attempt to fetch
- new tokens as needed.
+ready to be used by the Kubernetes kubectl command. The Kubernetes OIDC authenticator will attempt to fetch
+new tokens as needed.
 
 This script has been tested using [Keycloak](http://www.keycloak.org/)
 
 Please note that this script requires that a MFA (TOTP) code be used, for added security.
-                              
-Installation
--------------
-Install the jq dependency (https://stedolan.github.io/jq/download/) if you don't already have it. For MacOS: 
+
+## Installation
+
+Install the jq dependency (https://stedolan.github.io/jq/download/) if you don't already have it. For MacOS:
 
 `brew install jq`
 
@@ -25,18 +24,23 @@ Copy the [k8s-auth-client.sh](k8s-auth-client.sh) script somewhere on your path,
 Create a config file named [.k8s-auth-client](.k8s-auth-client) in your home folder. Edit the values to fit your setup.
 
 MacOS specific configuration:
+
 ###
 
-Add a Keychain entry for the identity provider account you use to authenticate as a generic password. 
+Add a Keychain entry for the identity provider account you use to authenticate as a generic password.
 Name the entry `k8s-auth-client`, with the identity provider username in the "Account" field.
 
+## Usage
 
-Usage
------
 `k8s-auth-client.sh <Kubernetes user to log in>`
- 
- If you have set a MacOS Keychain password as described under installation these credentials will be fetched
- and used automatically. Any credentials configured in the config file will override these. If using the config
- file to store credentials please remember to restrict access to it appropriately.
 
+If you have set a MacOS Keychain password as described under installation these credentials will be fetched
+and used automatically. Any credentials configured in the config file will override these. If using the config
+file to store credentials please remember to restrict access to it appropriately.
 
+## Keycloak specific stuff
+
+As of keycloak 6.x (and other versions).
+
+The client need to be a `confidential` client.
+You need to enable `Direct access grants enabled` and `Service accounts enabled`.

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Copy the [k8s-auth-client.sh](k8s-auth-client.sh) script somewhere on your path,
 
 `chmod u+x k8s-auth-client.sh`
 
-Create a config file named [.k8s-auth-client](.k8s-auth-client) in your home folder. Edit the values to fit your setup.
+Create a config file named [<Kubernetes user to log in>.k8s-auth-client](.k8s-auth-client) in your `~/.kube/` folder. Edit the values to fit your setup.
 
 MacOS specific configuration:
 
@@ -38,9 +38,12 @@ If you have set a MacOS Keychain password as described under installation these 
 and used automatically. Any credentials configured in the config file will override these. If using the config
 file to store credentials please remember to restrict access to it appropriately.
 
-## Keycloak specific stuff
+## Keycloak
 
 As of keycloak 6.x (and other versions).
 
-The client need to be a `confidential` client.
-You need to enable `Direct access grants enabled` and `Service accounts enabled`.
+You should create a client for your cluster. The client needs to be a `confidential` client.
+You need to enable `Direct access grants enabled` and `Service accounts enabled` on the Client page.
+You can use a custom group mapper to map groups with full path to your id token.
+
+WARNING: A token that takes long to expire is a security issue. You can increase the refresh token expiration via Realm/Tokens page, option `SSO Session Idle`.

--- a/k8s-auth-client.sh
+++ b/k8s-auth-client.sh
@@ -22,7 +22,7 @@ set -o nounset
 read -p 'MFA code:' TOTP
 
 #fetch and parse tokens from Keycloak
-KEYCLOAK_RESPONSE=$(curl -# --data "grant_type=password&client_id=$K8S_OIDC_CLIENT_ID&username=$K8S_AUTH_USERNAME&password=$K8S_AUTH_PASSWORD&scope=oidc&client_secret=$K8S_OIDC_CLIENT_SECRET&totp=$TOTP" $K8S_OIDC_TOKEN_ENDPOINT)
+KEYCLOAK_RESPONSE=$(curl -# --data "grant_type=password&client_id=$K8S_OIDC_CLIENT_ID&username=$K8S_AUTH_USERNAME&password=$K8S_AUTH_PASSWORD&scope=openid&client_secret=$K8S_OIDC_CLIENT_SECRET&totp=$TOTP" $K8S_OIDC_TOKEN_ENDPOINT)
 K8S_REFRESH_TOKEN=$(echo ${KEYCLOAK_RESPONSE} | jq -r '.refresh_token')
 K8S_ID_TOKEN=$(echo ${KEYCLOAK_RESPONSE} | jq -r '.id_token')
 

--- a/k8s-auth-client.sh
+++ b/k8s-auth-client.sh
@@ -1,14 +1,16 @@
-#!/bin/bash
+#!/bin/bash -x
 if [ "$#" -ne 1 ] ; then
   echo "Usage: k8s-auth-client.sh <K8S account name> " >&2
   exit 1
 fi
 
+KUBE_CONFIG_USERNAME=$1
+
 #Basic error handling
 set -o errexit
 set -o pipefail
 
-source ~/.k8s-auth-client
+source ~/.kube/$KUBE_CONFIG_USERNAME.k8s-auth-client
 
 if [[ -z $K8S_AUTH_USERNAME || -z $K8S_AUTH_PASSWORD ]]; then
 	#fetch password from keychain
@@ -27,7 +29,7 @@ K8S_REFRESH_TOKEN=$(echo ${KEYCLOAK_RESPONSE} | jq -r '.refresh_token')
 K8S_ID_TOKEN=$(echo ${KEYCLOAK_RESPONSE} | jq -r '.id_token')
 
 #set Kubernetes credentials
-kubectl config set-credentials $1 \
+kubectl config set-credentials $KUBE_CONFIG_USERNAME \
 	--auth-provider=oidc \
 	--auth-provider-arg=idp-issuer-url=$K8S_OIDC_ISSUER \
 	--auth-provider-arg=client-id=$K8S_OIDC_CLIENT_ID \


### PR DESCRIPTION
* Moved configuration to ~/.kube folder
* Allow for multiple config files - with food defaults
* Updated to use `scope=openid` - works for keycloak (should be customizable) 