### PR TITLE
exit with error code if the KEYCLOAK_RESPONSE contains an error message

### DIFF
--- a/k8s-auth-client.sh
+++ b/k8s-auth-client.sh
@@ -20,13 +20,17 @@ fi
 
 set -o nounset
 
-
 read -p 'MFA code:' TOTP
 
 #fetch and parse tokens from Keycloak
+
 KEYCLOAK_RESPONSE=$(curl -# --data "grant_type=password&client_id=$K8S_OIDC_CLIENT_ID&username=$K8S_AUTH_USERNAME&password=$K8S_AUTH_PASSWORD&scope=openid&client_secret=$K8S_OIDC_CLIENT_SECRET&totp=$TOTP" $K8S_OIDC_TOKEN_ENDPOINT)
 K8S_REFRESH_TOKEN=$(echo ${KEYCLOAK_RESPONSE} | jq -r '.refresh_token')
 K8S_ID_TOKEN=$(echo ${KEYCLOAK_RESPONSE} | jq -r '.id_token')
+K8S_ERROR=$(echo ${KEYCLOAK_RESPONSE} | jq -r '.error')
+
+# Exit if the server returns an error
+[[ ${K8S_ERROR} != "null" ]] && echo ${K8S_ERROR} && exit 1;
 
 #set Kubernetes credentials
 kubectl config set-credentials $KUBE_CONFIG_USERNAME \


### PR DESCRIPTION
Hello,

1. Thank you for creating this project. I found it from [this Medium post](https://medium.com/@mrbobbytables/kubernetes-day-2-operations-authn-authz-with-oidc-and-a-little-help-from-keycloak-de4ea1bdbbe).

2. I deployed my Keycloak instance at `auth.mydomain.com` so I removed the `/auth` base path and wound up incorrectly configuring. However, I got silent failure, where in ~/.kube/config the tokens were "null".

3. I echo'ed the KEYCLOAK_RESPONSE and saw that ~they~ the response is JSON but can contain an error message. So this merge request is just to attempt to detect and exit the script to help others avoid false positives.

Hope this helps, let me know if you'd rather I make the if statements in block form, or if you prefer a different way to exit on error.

Cheers,
Adam